### PR TITLE
問題の重複を解消

### DIFF
--- a/Modules/Sources/Core/DrillLevelSelector.swift
+++ b/Modules/Sources/Core/DrillLevelSelector.swift
@@ -18,6 +18,17 @@ public extension DrillLevelSelector {
     var id: DrillGenerator<Drill>.ID {
         generator.id
     }
+    
+    func coveredDrills(from options: [Drill.Option], count: Int) -> [Drill] {
+        (0..<count)
+            .map { index in
+                .init(
+                    options: options.shuffled(),
+                    answer: options[index < options.count ? index : (0..<options.count).randomElement() ?? 0]
+                )
+            }
+            .shuffled()
+    }
 }
 
 #if DEBUG

--- a/Modules/Sources/Drills/Drills/ColorDrill/ColorDrillLevelSelector.swift
+++ b/Modules/Sources/Drills/Drills/ColorDrill/ColorDrillLevelSelector.swift
@@ -31,7 +31,7 @@ public enum ColorDrillLevelSelector: DrillLevelSelector {
                 nextID: .colorBasic2,
                 title: L10n.Common.Level.basic1,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in ColorDrill(options: [.red, .blue, .yellow, .green].shuffled()) } },
+                generate: { coveredDrills(from: [.red, .blue, .yellow, .green], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -50,7 +50,7 @@ public enum ColorDrillLevelSelector: DrillLevelSelector {
                 nextID: .colorBasic3,
                 title: L10n.Common.Level.basic2,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in ColorDrill(options: [.white, .black, .lightBlue, .pink].shuffled()) } },
+                generate: { coveredDrills(from: [.white, .black, .lightBlue, .pink], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -69,7 +69,7 @@ public enum ColorDrillLevelSelector: DrillLevelSelector {
                 nextID: .colorAdvanced1,
                 title: L10n.Common.Level.basic3,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in ColorDrill(options: [.orange, .purple, .gray, .brown].shuffled()) } },
+                generate: { coveredDrills(from: [.orange, .purple, .gray, .brown], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in

--- a/Modules/Sources/Drills/Drills/CreatureDrill/CreatureDrillLevelSelector.swift
+++ b/Modules/Sources/Drills/Drills/CreatureDrill/CreatureDrillLevelSelector.swift
@@ -36,7 +36,7 @@ public enum CreatureDrillLevelSelector: DrillLevelSelector {
                 nextID: .creatureAnimal2,
                 title: L10n.Creature.Level.animal1,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.dog🐕, .cat🐈, .pig🐖, .rabbit🐇].shuffled()) } },
+                generate: { coveredDrills(from: [.dog🐕, .cat🐈, .pig🐖, .rabbit🐇], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -55,7 +55,7 @@ public enum CreatureDrillLevelSelector: DrillLevelSelector {
                 nextID: .creatureAnimal3,
                 title: L10n.Creature.Level.animal2,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.elephant🐘, .giraffe🦒, .chipmunk🐿️, .cow🐄].shuffled()) } },
+                generate: { coveredDrills(from: [.elephant🐘, .giraffe🦒, .chipmunk🐿️, .cow🐄], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -74,7 +74,7 @@ public enum CreatureDrillLevelSelector: DrillLevelSelector {
                 nextID: .creatureAnimal4,
                 title: L10n.Creature.Level.animal3,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.horse🐎, .monkey🐒, .mouse🐁, .tiger🐅].shuffled()) } },
+                generate: { coveredDrills(from: [.horse🐎, .monkey🐒, .mouse🐁, .tiger🐅], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -93,7 +93,7 @@ public enum CreatureDrillLevelSelector: DrillLevelSelector {
                 nextID: .creatureBird,
                 title: L10n.Creature.Level.animal4,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.zebra🦓, .camel🐪, .kangaroo🦘, .rhinoceros🦏].shuffled()) } },
+                generate: { coveredDrills(from: [.zebra🦓, .camel🐪, .kangaroo🦘, .rhinoceros🦏], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -112,7 +112,7 @@ public enum CreatureDrillLevelSelector: DrillLevelSelector {
                 nextID: .creatureReptile,
                 title: L10n.Creature.Level.bird,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.rooster🐓, .owl🦉, .flamingo🦩, .swan🦢, .duck🦆, .bat🦇].shuffled()) } },
+                generate: { coveredDrills(from: [.rooster🐓, .owl🦉, .flamingo🦩, .swan🦢, .duck🦆, .bat🦇], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -131,7 +131,7 @@ public enum CreatureDrillLevelSelector: DrillLevelSelector {
                 nextID: .creatureMarineLife,
                 title: L10n.Creature.Level.reptile,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.turtle🐢, .crocodile🐊, .lizard🦎, .snake🐍].shuffled()) } },
+                generate: { coveredDrills(from: [.turtle🐢, .crocodile🐊, .lizard🦎, .snake🐍], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -150,7 +150,7 @@ public enum CreatureDrillLevelSelector: DrillLevelSelector {
                 nextID: .creatureInsect,
                 title: L10n.Creature.Level.marineLife,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.whale🐋, .dolphin🐬, .shark🦈, .octopus🐙].shuffled()) } },
+                generate: { coveredDrills(from: [.whale🐋, .dolphin🐬, .shark🦈, .octopus🐙], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -169,7 +169,7 @@ public enum CreatureDrillLevelSelector: DrillLevelSelector {
                 nextID: .creatureAdvanced1,
                 title: L10n.Creature.Level.insect,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.bug🐛, .butterfly🦋, .ant🐜, .honeybee🐝, .ladyBeetle🐞, .spider🕷].shuffled()) } },
+                generate: { coveredDrills(from: [.bug🐛, .butterfly🦋, .ant🐜, .honeybee🐝, .ladyBeetle🐞, .spider🕷], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in

--- a/Modules/Sources/Drills/Drills/FruitsAndVegetablesDrill/FruitsAndVegetablesDrillLevelSelector.swift
+++ b/Modules/Sources/Drills/Drills/FruitsAndVegetablesDrill/FruitsAndVegetablesDrillLevelSelector.swift
@@ -34,7 +34,7 @@ public enum FruitsAndVegetablesDrillLevelSelector: DrillLevelSelector {
                 nextID: .fruitsAndVegetablesVegetable2,
                 title: L10n.FruitsAndVegetables.Level.vegetable1,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.tomato🍅, .eggplant🍆, .potato🥔, .carrot🥕].shuffled()) } },
+                generate: { coveredDrills(from: [.tomato🍅, .eggplant🍆, .potato🥔, .carrot🥕], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -53,7 +53,7 @@ public enum FruitsAndVegetablesDrillLevelSelector: DrillLevelSelector {
                 nextID: .fruitsAndVegetablesVegetable3,
                 title: L10n.FruitsAndVegetables.Level.vegetable2,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.onion🧅, .cucumber🥒, .corn🌽, .broccoli🥦].shuffled()) } },
+                generate: { coveredDrills(from: [.onion🧅, .cucumber🥒, .corn🌽, .broccoli🥦], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -72,7 +72,7 @@ public enum FruitsAndVegetablesDrillLevelSelector: DrillLevelSelector {
                 nextID: .fruitsAndVegetablesFruit1,
                 title: L10n.FruitsAndVegetables.Level.vegetable3,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.sweetPotato🍠, .greenBellPepper🫑, .chestnuts🌰, .mushrooms🍄].shuffled()) } },
+                generate: { coveredDrills(from: [.sweetPotato🍠, .greenBellPepper🫑, .chestnuts🌰, .mushrooms🍄], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -91,7 +91,7 @@ public enum FruitsAndVegetablesDrillLevelSelector: DrillLevelSelector {
                 nextID: .fruitsAndVegetablesFruit2,
                 title: L10n.FruitsAndVegetables.Level.fruit1,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.orange🍊, .apple🍎, .grape🍇, .kiwi🥝].shuffled()) } },
+                generate: { coveredDrills(from: [.orange🍊, .apple🍎, .grape🍇, .kiwi🥝], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -110,7 +110,7 @@ public enum FruitsAndVegetablesDrillLevelSelector: DrillLevelSelector {
                 nextID: .fruitsAndVegetablesFruit3,
                 title: L10n.FruitsAndVegetables.Level.fruit2,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.watermelon🍉, .lemon🍋, .peach🍑, .strawberry🍓].shuffled()) } },
+                generate: { coveredDrills(from: [.watermelon🍉, .lemon🍋, .peach🍑, .strawberry🍓], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -129,7 +129,7 @@ public enum FruitsAndVegetablesDrillLevelSelector: DrillLevelSelector {
                 nextID: .fruitsAndVegetablesAdvanced1,
                 title: L10n.FruitsAndVegetables.Level.fruit3,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.banana🍌, .pineapple🍍, .melon🍈, .blueberry🫐].shuffled()) } },
+                generate: { coveredDrills(from: [.banana🍌, .pineapple🍍, .melon🍈, .blueberry🫐], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in

--- a/Modules/Sources/Drills/Drills/FunnyAnimalDrill/FunnyAnimalDrillLevelSelector.swift
+++ b/Modules/Sources/Drills/Drills/FunnyAnimalDrill/FunnyAnimalDrillLevelSelector.swift
@@ -30,7 +30,7 @@ public enum FunnyAnimalDrillLevelSelector: DrillLevelSelector {
                 nextID: .funnyAnimalBasic2,
                 title: L10n.Common.Level.basic1,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.dogFace🐶, .catFace🐱, .pigFace🐷, .rabbitFace🐰].shuffled()) } },
+                generate: { coveredDrills(from: [.dogFace🐶, .catFace🐱, .pigFace🐷, .rabbitFace🐰], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -49,7 +49,7 @@ public enum FunnyAnimalDrillLevelSelector: DrillLevelSelector {
                 nextID: .funnyAnimalBasic3,
                 title: L10n.Common.Level.basic2,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.lionFace🦁, .cowFace🐮, .horseFace🐴, .mouseFace🐭].shuffled()) } },
+                generate: { coveredDrills(from: [.lionFace🦁, .cowFace🐮, .horseFace🐴, .mouseFace🐭], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -68,7 +68,7 @@ public enum FunnyAnimalDrillLevelSelector: DrillLevelSelector {
                 nextID: .funnyAnimalAdvanced1,
                 title: L10n.Common.Level.basic3,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.monkeyFace🐵, .pandaFace🐼, .tigerFace🐯, .bearFace🐻].shuffled()) } },
+                generate: { coveredDrills(from: [.monkeyFace🐵, .pandaFace🐼, .tigerFace🐯, .bearFace🐻], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in

--- a/Modules/Sources/Drills/Drills/HiraganaDrill/HiraganaDrillLevelSelector.swift
+++ b/Modules/Sources/Drills/Drills/HiraganaDrill/HiraganaDrillLevelSelector.swift
@@ -48,7 +48,7 @@ public enum HiraganaDrillLevelSelector: DrillLevelSelector {
                 nextID: .hiraganaか行,
                 title: "あ\(L10n.Hiragana.row)",
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: HiraganaDrillOption.あ行.shuffled()) } },
+                generate: { coveredDrills(from: HiraganaDrillOption.あ行, count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -67,7 +67,7 @@ public enum HiraganaDrillLevelSelector: DrillLevelSelector {
                 nextID: .hiraganaReview1,
                 title: "か\(L10n.Hiragana.row)",
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: HiraganaDrillOption.か行.shuffled()) } },
+                generate: { coveredDrills(from: HiraganaDrillOption.か行, count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -106,7 +106,7 @@ public enum HiraganaDrillLevelSelector: DrillLevelSelector {
                 nextID: .hiraganaReview2,
                 title: "さ\(L10n.Hiragana.row)",
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: HiraganaDrillOption.さ行.shuffled()) } },
+                generate: { coveredDrills(from: HiraganaDrillOption.さ行, count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -144,7 +144,7 @@ public enum HiraganaDrillLevelSelector: DrillLevelSelector {
                 nextID: .hiraganaReview3,
                 title: "た\(L10n.Hiragana.row)",
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: HiraganaDrillOption.た行.shuffled()) } },
+                generate: { coveredDrills(from: HiraganaDrillOption.た行, count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -182,7 +182,7 @@ public enum HiraganaDrillLevelSelector: DrillLevelSelector {
                 nextID: .hiraganaReview4,
                 title: "な\(L10n.Hiragana.row)",
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: HiraganaDrillOption.な行.shuffled()) } },
+                generate: { coveredDrills(from: HiraganaDrillOption.な行, count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -220,7 +220,7 @@ public enum HiraganaDrillLevelSelector: DrillLevelSelector {
                 nextID: .hiraganaReview5,
                 title: "は\(L10n.Hiragana.row)",
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: HiraganaDrillOption.は行.shuffled()) } },
+                generate: { coveredDrills(from: HiraganaDrillOption.は行, count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -258,7 +258,7 @@ public enum HiraganaDrillLevelSelector: DrillLevelSelector {
                 nextID: .hiraganaReview6,
                 title: "ま\(L10n.Hiragana.row)",
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: HiraganaDrillOption.ま行.shuffled()) } },
+                generate: { coveredDrills(from: HiraganaDrillOption.ま行, count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -296,7 +296,7 @@ public enum HiraganaDrillLevelSelector: DrillLevelSelector {
                 nextID: .hiraganaReview7,
                 title: "や\(L10n.Hiragana.row)",
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: HiraganaDrillOption.や行.shuffled()) } },
+                generate: { coveredDrills(from: HiraganaDrillOption.や行, count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -334,7 +334,7 @@ public enum HiraganaDrillLevelSelector: DrillLevelSelector {
                 nextID: .hiraganaReview8,
                 title: "ら\(L10n.Hiragana.row)",
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: HiraganaDrillOption.ら行.shuffled()) } },
+                generate: { coveredDrills(from: HiraganaDrillOption.ら行, count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -372,7 +372,7 @@ public enum HiraganaDrillLevelSelector: DrillLevelSelector {
                 nextID: .hiraganaReview9,
                 title: "わ\(L10n.Hiragana.row)",
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: HiraganaDrillOption.わ行.shuffled()) } },
+                generate: { coveredDrills(from: HiraganaDrillOption.わ行, count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in

--- a/Modules/Sources/Drills/Drills/NationalFlagDrill/NationalFlagDrillLevelSelector.swift
+++ b/Modules/Sources/Drills/Drills/NationalFlagDrill/NationalFlagDrillLevelSelector.swift
@@ -37,7 +37,7 @@ public enum NationalFlagDrillLevelSelector: DrillLevelSelector {
                 nextID: .nationalFlagAsia2AndOceania,
                 title: L10n.NationalFlag.Level.asia1,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.japan🇯🇵, .korea🇰🇷, .china🇨🇳, .thailand🇹🇭].shuffled()) } },
+                generate: { coveredDrills(from: [.japan🇯🇵, .korea🇰🇷, .china🇨🇳, .thailand🇹🇭], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -56,7 +56,7 @@ public enum NationalFlagDrillLevelSelector: DrillLevelSelector {
                 nextID: .nationalFlagAmericas1,
                 title: L10n.NationalFlag.Level.asia2AndOceania,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.india🇮🇳, .indonesia🇮🇩, .singapore🇸🇬, .australia🇦🇺].shuffled()) } },
+                generate: { coveredDrills(from: [.india🇮🇳, .indonesia🇮🇩, .singapore🇸🇬, .australia🇦🇺], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -75,7 +75,7 @@ public enum NationalFlagDrillLevelSelector: DrillLevelSelector {
                 nextID: .nationalFlagAmericas2,
                 title: L10n.NationalFlag.Level.americas1,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.unitedstate🇺🇸, .canada🇨🇦, .mexico🇲🇽, .brazil🇧🇷].shuffled()) } },
+                generate: { coveredDrills(from: [.unitedstate🇺🇸, .canada🇨🇦, .mexico🇲🇽, .brazil🇧🇷], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -94,7 +94,7 @@ public enum NationalFlagDrillLevelSelector: DrillLevelSelector {
                 nextID: .nationalFlagEurope1,
                 title: L10n.NationalFlag.Level.americas2,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.argentina🇦🇷, .uruguay🇺🇾, .peru🇵🇪, .paraguay🇵🇾].shuffled()) } },
+                generate: { coveredDrills(from: [.argentina🇦🇷, .uruguay🇺🇾, .peru🇵🇪, .paraguay🇵🇾], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -113,7 +113,7 @@ public enum NationalFlagDrillLevelSelector: DrillLevelSelector {
                 nextID: .nationalFlagEurope2,
                 title: L10n.NationalFlag.Level.europe1,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.unitedkingdom🇬🇧, .germany🇩🇪, .france🇫🇷, .italy🇮🇹].shuffled()) } },
+                generate: { coveredDrills(from: [.unitedkingdom🇬🇧, .germany🇩🇪, .france🇫🇷, .italy🇮🇹], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -132,7 +132,7 @@ public enum NationalFlagDrillLevelSelector: DrillLevelSelector {
                 nextID: .nationalFlagEurope3,
                 title: L10n.NationalFlag.Level.europe2,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.spain🇪🇸, .portugal🇵🇹, .russia🇷🇺, .netherlands🇳🇱].shuffled()) } },
+                generate: { coveredDrills(from: [.spain🇪🇸, .portugal🇵🇹, .russia🇷🇺, .netherlands🇳🇱], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -151,7 +151,7 @@ public enum NationalFlagDrillLevelSelector: DrillLevelSelector {
                 nextID: .nationalFlagEurope4,
                 title: L10n.NationalFlag.Level.europe3,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.switzerland🇨🇭, .sweeden🇸🇪, .norway🇳🇴, .poland🇵🇱].shuffled()) } },
+                generate: { coveredDrills(from: [.switzerland🇨🇭, .sweeden🇸🇪, .norway🇳🇴, .poland🇵🇱], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -170,7 +170,7 @@ public enum NationalFlagDrillLevelSelector: DrillLevelSelector {
                 nextID: .nationalFlagAfrica,
                 title: L10n.NationalFlag.Level.europe4,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.belgium🇧🇪, .greece🇬🇷, .hungary🇭🇺, .ukraine🇺🇦].shuffled()) } },
+                generate: { coveredDrills(from: [.belgium🇧🇪, .greece🇬🇷, .hungary🇭🇺, .ukraine🇺🇦], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -189,7 +189,7 @@ public enum NationalFlagDrillLevelSelector: DrillLevelSelector {
                 nextID: .nationalFlagAdvanced1,
                 title: L10n.NationalFlag.Level.africa,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.cameroun🇨🇲, .kenya🇰🇪, .nigeria🇳🇬, .southafrica🇿🇦].shuffled()) } },
+                generate: { coveredDrills(from: [.cameroun🇨🇲, .kenya🇰🇪, .nigeria🇳🇬, .southafrica🇿🇦], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in

--- a/Modules/Sources/Drills/Drills/NumberDrill/NumberDrillLevelSelector.swift
+++ b/Modules/Sources/Drills/Drills/NumberDrill/NumberDrillLevelSelector.swift
@@ -35,7 +35,7 @@ public enum NumberDrillLevelSelector: DrillLevelSelector {
                 nextID: .numberDice456,
                 title: "1~3",
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.dice1, .dice2, .dice3].shuffled()) } },
+                generate: { coveredDrills(from: [.dice1, .dice2, .dice3], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -54,7 +54,7 @@ public enum NumberDrillLevelSelector: DrillLevelSelector {
                 nextID: .numberDiceAll,
                 title: "4~6",
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.dice4, .dice5, .dice6].shuffled()) } },
+                generate: { coveredDrills(from: [.dice4, .dice5, .dice6], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -73,7 +73,7 @@ public enum NumberDrillLevelSelector: DrillLevelSelector {
                 nextID: .numberFinger,
                 title: "1~6",
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.dice1, .dice2, .dice3, .dice4, .dice5, .dice6].shuffled().prefix(4).toArray()) } },
+                generate: { coveredDrills(from: [.dice1, .dice2, .dice3, .dice4, .dice5, .dice6], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -93,7 +93,7 @@ public enum NumberDrillLevelSelector: DrillLevelSelector {
                 nextID: .numberNumeral0123,
                 title: L10n.Number.Level.finger,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.finger1, .finger2, .finger3, .finger4, .finger5].shuffled().prefix(4).toArray()) } },
+                generate: { coveredDrills(from: [.finger1, .finger2, .finger3, .finger4, .finger5], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -112,7 +112,7 @@ public enum NumberDrillLevelSelector: DrillLevelSelector {
                 nextID: .numberNumeral4567,
                 title: "\(L10n.Number.Drill.title) 0~3",
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.numeral0, .numeral1, .numeral2, .numeral3].shuffled()) } },
+                generate: { coveredDrills(from: [.numeral0, .numeral1, .numeral2, .numeral3], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -131,7 +131,7 @@ public enum NumberDrillLevelSelector: DrillLevelSelector {
                 nextID: .numberNumeral8910,
                 title: "\(L10n.Number.Drill.title) 4~7",
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.numeral4, .numeral5, .numeral6, .numeral7].shuffled()) } },
+                generate: { coveredDrills(from: [.numeral4, .numeral5, .numeral6, .numeral7], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -150,7 +150,7 @@ public enum NumberDrillLevelSelector: DrillLevelSelector {
                 nextID: .numberNumeralAll,
                 title: "\(L10n.Number.Drill.title) 8~10",
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.numeral8, .numeral9, .numeral10].shuffled()) } },
+                generate: { coveredDrills(from: [.numeral8, .numeral9, .numeral10], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in

--- a/Modules/Sources/Drills/Drills/ShapeDrill/ShapeDrillLevelSelector.swift
+++ b/Modules/Sources/Drills/Drills/ShapeDrill/ShapeDrillLevelSelector.swift
@@ -29,7 +29,7 @@ public enum ShapeDrillLevelSelector: DrillLevelSelector {
                 nextID: .shapeBasic2,
                 title: L10n.Common.Level.basic1,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.circle, .cross].shuffled()) } },
+                generate: { coveredDrills(from: [.circle, .cross], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -48,7 +48,7 @@ public enum ShapeDrillLevelSelector: DrillLevelSelector {
                 nextID: .shapeBasic3,
                 title: L10n.Common.Level.basic2,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.circle, .triangle, .square].shuffled()) } },
+                generate: { coveredDrills(from: [.circle, .triangle, .square], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in
@@ -67,7 +67,7 @@ public enum ShapeDrillLevelSelector: DrillLevelSelector {
                 nextID: .shapeAdvanced1,
                 title: L10n.Common.Level.basic3,
                 requirements: L10n.Common.Level.requirementsFormat(10, 60),
-                generate: { (0..<10).map { _ in .init(options: [.heart, .star].shuffled()) } },
+                generate: { coveredDrills(from: [.heart, .star], count: 10) },
                 timeLimit: 60,
                 penalty: .shuffle,
                 star1: .init(description: L10n.Common.Level.clear) { time, missCount in

--- a/Modules/Tests/TapDrillForKidsTests/CoreTests/DrillLevelSelectorTests.swift
+++ b/Modules/Tests/TapDrillForKidsTests/CoreTests/DrillLevelSelectorTests.swift
@@ -1,0 +1,20 @@
+//
+//  DrillLevelSelectorTests.swift
+//  
+//
+//  Created by 若江照仁 on 2023/03/29.
+//
+
+import XCTest
+@testable import Core
+
+final class DrillLevelSelectorTests: XCTestCase {
+    func testCoveredDrillsTests() throws {
+        let dummyOptions = DrillLevelSelectorDummy.Drill.Option.allCases
+        let coveredDrillAnswers = DrillLevelSelectorDummy.level1.coveredDrills(from: dummyOptions, count: dummyOptions.count).map { $0.answer }
+        let uniqueAnswersCount = Set(coveredDrillAnswers).count
+        
+        XCTAssertEqual(dummyOptions.count, uniqueAnswersCount, "答えが全て違うなら選択数と一意となる答えの数が同じになるはず")
+        
+    }
+}


### PR DESCRIPTION
close #91 

- DrillLevelSelectorにcoveredDrillsメソッドを作成
- 基本問題系の同じ問題が並ぶ場合は全てこのメソッドで問題を生成